### PR TITLE
Add `jupyter_lite_config.json` to define the list of apps

### DIFF
--- a/jupyter_lite_config.json
+++ b/jupyter_lite_config.json
@@ -1,5 +1,6 @@
 {
   "LiteBuildConfig": {
-    "app": ["repl"]
+    "app": ["repl"],
+    "no_unused_shared_packages": true
   }
 }

--- a/jupyter_lite_config.json
+++ b/jupyter_lite_config.json
@@ -1,0 +1,5 @@
+{
+  "LiteBuildConfig": {
+    "app": ["repl"]
+  }
+}

--- a/overrides.json
+++ b/overrides.json
@@ -1,0 +1,5 @@
+{
+  "@jupyterlab/console-extension:tracker": {
+    "interactionMode": "terminal"
+  }
+}


### PR DESCRIPTION
JupyterLite lets you define which app to export in the deployed bundle: https://jupyterlite.readthedocs.io/en/latest/configuring.html#applications

We can also enable disk-saving optimizations such as `no_unused_shared_packages`: https://jupyterlite.readthedocs.io/en/latest/configuring.html#removing-unused-shared-packages

### Changes

- [x] Only deploy the `repl` app
- [x] Enable `no_unused_shared_packages` to save disk space on deploy
- [x] Use <kbd>Enter</kbd> instead of <kbd>Shift Enter</kbd> to execute code in the REPL by setting `interactionMode` to `terminal`