### PR TITLE
Fix typo for `apps`

### DIFF
--- a/jupyter_lite_config.json
+++ b/jupyter_lite_config.json
@@ -1,6 +1,6 @@
 {
   "LiteBuildConfig": {
-    "app": ["repl"],
+    "apps": ["repl"],
     "no_unused_shared_packages": true
   }
 }


### PR DESCRIPTION
Follow-up to #1 

There was a typo in the config file.

cc @ivanistheone 